### PR TITLE
[fix] Do not scroll when position changes on a non-scrollable event

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2922,7 +2922,7 @@ function Ace2Inner(){
       var shouldScrollWhenCaretIsAtBottomOfViewport =  scrollSettings.scrollWhenCaretIsInTheLastLineOfViewport;
       if (shouldScrollWhenCaretIsAtBottomOfViewport) {
         // avoid scrolling when pad loads
-        var isScrollableEvent = !isPadLoading(currentCallStack.type);
+        var isScrollableEvent = !isPadLoading(currentCallStack.type) && isScrollableEditEvent(currentCallStack.type);
         // avoid scrolling when selection includes multiple lines -- user can potentially be selecting more lines
         // than it fits on viewport
         var multipleLinesSelected = rep.selStart[0] !== rep.selEnd[0];

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -6,9 +6,9 @@ exports.getPosition = function ()
   var rect, line;
   var editor = $('#innerdocbody')[0];
   var range = getSelectionRange();
-  var isSelectionInsideTheEditor = $(range.endContainer).closest('body')[0].id === 'innerdocbody';
+  var isSelectionInsideTheEditor = range && $(range.endContainer).closest('body')[0].id === 'innerdocbody';
 
-  if(range && isSelectionInsideTheEditor){
+  if(isSelectionInsideTheEditor){
     // when we have the caret in an empty line, e.g. a line with only a <br>,
     // getBoundingClientRect() returns all dimensions value as 0
     var selectionIsInTheBeginningOfLine = range.endOffset > 0;


### PR DESCRIPTION
Fix https://trello.com/c/DgvXI6B2/960.

Also simplify code to scroll when caret position is changed:
- remove unused code (distanceToBottomOfViewport)
- re-write some comments
- add TODO to review comment later
- fix logic to avoid error when range is undefined

